### PR TITLE
fix: Some first steps to get it to run for Munen

### DIFF
--- a/README.org
+++ b/README.org
@@ -117,14 +117,24 @@ This project is maintained by [[https://200ok.ch/][200ok GmbH]].
 You can customize Dictate's behavior by creating a =dictate.yml=
 configuration file in the *SAME* directory where you call =dictate=.
 
+The values in this example are also the defaults.
+
 Example:
 
 #+begin_src yaml
-api-key: "sk-..."                    # Your OpenAI API key
+# audio
 device: "default"                    # Audio input device (e.g., "default", "hw:1,0")
-delay: 5                             # Typing delay in milliseconds
-model: "gpt-4o-transcribe"           # Whisper model to use
-api-path: "/v1/audio/transcriptions" # API endpoint path
+# silence
+volume: 2                            # Maximum volume of silence in percentage
+duration: 1.5                        # Minimum duration of silence in secs
+# transcription
 api-root: "https://api.openai.com"   # API root URL
-kill-i3status: false                 # Whether to kill i3status during dictation
+api-path: "/v1/audio/transcriptions" # API endpoint path
+api-key: "sk-..."                    # Your OpenAI API key
+model: "gpt-4o-transcribe"           # Whisper model to use
+# typing
+delay: 25                            # Typing delay in milliseconds
+# misc
+i3status: false                      # Whether to reload i3status on toggle
+emojis: false                        # Dis-/enable emoji feature
 #+end_src

--- a/README.org
+++ b/README.org
@@ -111,3 +111,20 @@ whether recording is active or inactive:
 ** License
 
 This project is maintained by [[https://200ok.ch/][200ok GmbH]].
+
+** Configuration
+
+You can customize Dictate's behavior by creating a =dictate.yml=
+configuration file in the *SAME* directory where you call =dictate=.
+
+Example:
+
+#+begin_src yaml
+api-key: "sk-..."                    # Your OpenAI API key
+device: "default"                    # Audio input device (e.g., "default", "hw:1,0")
+delay: 5                             # Typing delay in milliseconds
+model: "gpt-4o-transcribe"           # Whisper model to use
+api-path: "/v1/audio/transcriptions" # API endpoint path
+api-root: "https://api.openai.com"   # API root URL
+kill-i3status: false                 # Whether to kill i3status during dictation
+#+end_src

--- a/dictate.bb
+++ b/dictate.bb
@@ -29,6 +29,7 @@ Options:
   -v --volume=<colume>      Maximum volume of silence in percentage [default: 2]
   -t --duration=<duration>  Minimum duration of silence in secs [default: 1.5]
   -e --emojis               Enable emoji support.
+  -k --kill-i3status        Kill i3status when toggling (configurable via dictate.yml)
 
 Examples:
   dictate --service                   Start service with default device
@@ -169,14 +170,15 @@ See the README for more details: https://github.com/200ok-ch/dictate
   ;; Start recording loop
   (recording-loop config))
 
-(defn toggle-mode! []
+(defn toggle-mode! [config]
   "Toggle between active and inactive recording modes"
   (let [current-state (read-state)
         new-state (if (= current-state :active) :inactive :active)]
     (write-state! new-state)
     (println (str "Dictate mode: " (name new-state)))
-    ;; force update i3status for the instant red bubble
-    (p/shell "killall -USR1 i3status")
+    ;; force update i3status for the instant red bubble (if configured)
+    (when (:kill-i3status config)
+      (p/shell "killall -USR1 i3status"))
     ;;(notify-cmd (str "Mode: " (name new-state) (when (#{:active} new-state) (str " " indicator))))
     ))
 
@@ -187,7 +189,7 @@ See the README for more details: https://github.com/200ok-ch/dictate
       (start-service! config)
 
       (:toggle config)
-      (toggle-mode!)
+      (toggle-mode! config)
 
       :else
       (println usage))))

--- a/dictate.bb
+++ b/dictate.bb
@@ -21,7 +21,7 @@ Options:
   -a --device=<device>      Device to record from [default: default]
   -d --delay=<delay>        Type delay in millisecs [default: 25]
   -h --help                 Show this help message
-  -m --model=<model>        Model [default: whisper-1]
+  -m --model=<model>        Model [default: gpt-4o-transcribe]
   -p --api-path=<api-path>  API path [default: /v1/audio/transcriptions]
   -r --api-root=<api-root>  API root [default: https://api.openai.com]
   -s --service              Run as background service process
@@ -29,7 +29,7 @@ Options:
   -v --volume=<colume>      Maximum volume of silence in percentage [default: 2]
   -t --duration=<duration>  Minimum duration of silence in secs [default: 1.5]
   -e --emojis               Enable emoji support.
-  -k --kill-i3status        Kill i3status when toggling (configurable via dictate.yml)
+  -i --i3status             Reload i3status when toggling [default: false]
 
 Examples:
   dictate --service                   Start service with default device
@@ -179,9 +179,9 @@ See the README for more details: https://github.com/200ok-ch/dictate
         new-state (if (= current-state :active) :inactive :active)]
     (write-state! new-state)
     (println (str "Dictate mode: " (name new-state)))
-    ;; force update i3status for the instant red bubble (if configured)
-    (when (:kill-i3status config)
-      (p/shell "killall -USR1 i3status"))
+    (when (:i3status config)
+      ;; force update i3status for the instant red bubble (if configured)
+      (p/shell {:continue true} "killall -USR1 i3status"))
     ;;(notify-cmd (str "Mode: " (name new-state) (when (#{:active} new-state) (str " " indicator))))
     ))
 


### PR DESCRIPTION
I've put in about 45 min and I kinda can see that it sometimes works(;

Observations:

1. It looks to me that the config file has to be in the same folder where you call the 'thing' instead of having something like a canonical path `~/.config/tool/config.yml` 
2. When installed via bbin, then it won't find the emoji file. 

This means I have to currently check out the repo and then call it with `bb dictate.bb --service`.

Additionally, I cannot get the mute function to work.

But it's a great start, in theory I like it!